### PR TITLE
to support other cmake projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,12 +3,12 @@ cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
 project(DABC)
 
 #---Set paths where to put the libraries, executables and headers------------------------------
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 
 #--- where to search for cmake modules ----
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
 #--- Load some basic macros ---
 include(DabcBuildOptions)
@@ -27,3 +27,9 @@ get_property(__allHeaders GLOBAL PROPERTY DABC_HEADER_TARGETS)
 add_custom_target(move_headers ALL DEPENDS ${__allHeaders})
 
 DABC_SHOW_ENABLED_OPTIONS()
+
+install(TARGETS DabcBase DabcHadaq DabcMbs EXPORT dabcTargets)
+install(EXPORT dabcTargets
+        FILE dabcTargets.cmake
+        NAMESPACE dabc::
+        DESTINATION ${PROJECT_BINARY_DIR})

--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -11,7 +11,7 @@ get_property(_allLibs GLOBAL PROPERTY DABC_LIBRARY_TARGETS)
 foreach(ex ${applications})
    ExternalProject_Add(${ex}
                        DEPENDS ${_allLibs}
-                       CMAKE_ARGS -DCMAKE_PREFIX_PATH=${CMAKE_BINARY_DIR}
+                       CMAKE_ARGS -DCMAKE_PREFIX_PATH=${PROJECT_BINARY_DIR}
                        SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${ex}
                        BINARY_DIR ${ex}
                        INSTALL_COMMAND "")

--- a/base/CMakeLists.txt
+++ b/base/CMakeLists.txt
@@ -18,4 +18,4 @@ DABC_EXECUTABLE(dabc_exe
                 SOURCES run/dabc_exe.cxx
                 LIBRARIES DabcBase)
 
-configure_file(run/dabc_run ${CMAKE_BINARY_DIR}/bin/dabc_run COPYONLY)
+configure_file(run/dabc_run ${PROJECT_BINARY_DIR}/bin/dabc_run COPYONLY)

--- a/cmake/modules/DabcConfiguration.cmake
+++ b/cmake/modules/DabcConfiguration.cmake
@@ -1,8 +1,8 @@
 set(DABC_VERSION "2.11.0" CACHE STRING "DABC version" FORCE)
 
-set(DABC_INCLUDE_DIR "${CMAKE_BINARY_DIR}/include" CACHE STRING "DABC include dir" FORCE)
+set(DABC_INCLUDE_DIR "${PROJECT_BINARY_DIR}/include" CACHE STRING "DABC include dir" FORCE)
 
-set(DABC_LIBRARY_DIR "${CMAKE_BINARY_DIR}/lib" CACHE STRING "DABC include dir" FORCE)
+set(DABC_LIBRARY_DIR "${PROJECT_BINARY_DIR}/lib" CACHE STRING "DABC include dir" FORCE)
 
 set(DABC_LIBRARY "libDabcBase" CACHE STRING "DABC main library" FORCE)
 
@@ -46,22 +46,22 @@ else()
   set(DABC_DEBUGLEVEL 2)
 endif()
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/DABCConfig.cmake.in
-               ${CMAKE_BINARY_DIR}/DABCConfig.cmake @ONLY NEWLINE_STYLE UNIX)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/scripts/DABCConfig.cmake.in
+               ${PROJECT_BINARY_DIR}/DABCConfig.cmake @ONLY NEWLINE_STYLE UNIX)
 
 if(extrachecks)
   set(DABC_EXTRA_CHECKS "#define DABC_EXTRA_CHECKS")
 endif()
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/defines.h.in
-               ${CMAKE_BINARY_DIR}/include/dabc/defines.h @ONLY NEWLINE_STYLE UNIX)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/scripts/defines.h.in
+               ${PROJECT_BINARY_DIR}/include/dabc/defines.h @ONLY NEWLINE_STYLE UNIX)
 
 if(APPLE)
-   configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/dabclogin.mac.in
-                  ${CMAKE_BINARY_DIR}/dabclogin @ONLY NEWLINE_STYLE UNIX)
+   configure_file(${PROJECT_SOURCE_DIR}/cmake/scripts/dabclogin.mac.in
+                  ${PROJECT_BINARY_DIR}/dabclogin @ONLY NEWLINE_STYLE UNIX)
 else()
-   configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/dabclogin.linux.in
-                  ${CMAKE_BINARY_DIR}/dabclogin @ONLY NEWLINE_STYLE UNIX)
+   configure_file(${PROJECT_SOURCE_DIR}/cmake/scripts/dabclogin.linux.in
+                  ${PROJECT_BINARY_DIR}/dabclogin @ONLY NEWLINE_STYLE UNIX)
 endif()
 
 foreach(lib pthread dl)
@@ -72,9 +72,9 @@ if(NOT APPLE)
    find_library(DABC_RT_LIBRARY rt)
 endif()
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/modules/DabcMacros.cmake
-               ${CMAKE_BINARY_DIR}/DabcMacros.cmake COPYONLY)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/modules/DabcMacros.cmake
+               ${PROJECT_BINARY_DIR}/DabcMacros.cmake COPYONLY)
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/scripts/DABCUseFile.cmake.in
-               ${CMAKE_BINARY_DIR}/DABCUseFile.cmake @ONLY NEWLINE_STYLE UNIX)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/scripts/DABCUseFile.cmake.in
+               ${PROJECT_BINARY_DIR}/DABCUseFile.cmake @ONLY NEWLINE_STYLE UNIX)
 

--- a/cmake/modules/DabcMacros.cmake
+++ b/cmake/modules/DabcMacros.cmake
@@ -21,11 +21,11 @@ function(DABC_INSTALL_HEADERS dir)
   foreach (include_file ${headers})
     string(REPLACE "${CMAKE_CURRENT_SOURCE_DIR}/" "" fname ${include_file})
     set (src ${CMAKE_CURRENT_SOURCE_DIR}/${fname})
-    set (dst ${CMAKE_BINARY_DIR}/include/${fname})
+    set (dst ${PROJECT_BINARY_DIR}/include/${fname})
     add_custom_command(
       OUTPUT ${dst}
       COMMAND ${CMAKE_COMMAND} -E copy ${src} ${dst}
-      COMMENT "Copying header ${fname} to ${CMAKE_BINARY_DIR}/include"
+      COMMENT "Copying header ${fname} to ${PROJECT_BINARY_DIR}/include"
       DEPENDS ${src})
     list(APPEND dst_list ${dst})
   endforeach()

--- a/plugins/hadaq/CMakeLists.txt
+++ b/plugins/hadaq/CMakeLists.txt
@@ -12,4 +12,4 @@ DABC_EXECUTABLE(hldprint
                 SOURCES hldprint.cxx
                 LIBRARIES DabcBase DabcMbs DabcHadaq)
 
-file(COPY app hades spill start tdcmon test DESTINATION ${CMAKE_BINARY_DIR}/plugins/hadaq)
+file(COPY app hades spill start tdcmon test DESTINATION ${PROJECT_BINARY_DIR}/plugins/hadaq)

--- a/plugins/mbs/CMakeLists.txt
+++ b/plugins/mbs/CMakeLists.txt
@@ -10,4 +10,4 @@ DABC_EXECUTABLE(mbscmd
                 SOURCES utils/mbscmd.cxx
                 LIBRARIES DabcBase DabcMbs)
 
-file(COPY htm app DESTINATION ${CMAKE_BINARY_DIR}/plugins/mbs)
+file(COPY htm app DESTINATION ${PROJECT_BINARY_DIR}/plugins/mbs)


### PR DESCRIPTION
The changes allow for use with CMake's FetchContent_MakeAvailable and access to the libraries DabcBase, DabcHadaq and DabcMbs. At this point, only one project (github.com/SiFi-CC) has tested this.